### PR TITLE
Add get-iplayer to container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -48,8 +48,13 @@ WORKDIR /app
 ARG APP_UID=1000
 ARG APP_GID=1000
 
+# Get main project dependencies, then add the get-iplayer repository and download
+# FIXME This is supremely sucky (get-iplayer has a stupidly long list of dependencies) and should be replaced with a manual build stage
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends curl libpq-dev \
+  && apt-get install -y --no-install-recommends curl libpq-dev gpg \
+  && echo 'deb http://download.opensuse.org/repositories/home:/m-grant-prg/Debian_13/ /' | tee /etc/apt/sources.list.d/home:m-grant-prg.list \
+  && curl -fsSL https://download.opensuse.org/repositories/home:m-grant-prg/Debian_13/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/home_m-grant-prg.gpg > /dev/null \
+  && apt-get update && apt-get install -y --no-install-recommends get-iplayer \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man \
   && apt-get clean \
   && groupadd -g "${APP_GID}" python \


### PR DESCRIPTION
This is pretty horrific because there's a crazy long list of dependencies on the apt package, but it'll do for now.

#19 (but does not close)