### PR TITLE
Fix auto-scroll on unintended pages

### DIFF
--- a/slurp/templates/_base.html
+++ b/slurp/templates/_base.html
@@ -108,11 +108,7 @@
     {% endblock %}
 </main>
 </body>
-<script type="text/javascript">
-    const resizeObserver = new ResizeObserver((_) => {
-        window.scrollTo(0, document.body.scrollHeight);
-    });
-    resizeObserver.observe(document.body);
-</script>
+
+{% block js-post %}{% endblock %}
 
 </html>

--- a/slurp/templates/download.html
+++ b/slurp/templates/download.html
@@ -20,3 +20,12 @@
         <input type="Submit" value="Done!">
     </form>
 {% endblock %}
+
+{% block js-post %}
+    <script type="text/javascript">
+        const resizeObserver = new ResizeObserver((_) => {
+            window.scrollTo(0, document.body.scrollHeight);
+        });
+        resizeObserver.observe(document.body);
+    </script>
+{% endblock %}


### PR DESCRIPTION
I accidentally moved the auto-scroll javascript to the main page, which apparently is extremely annoying. This resolves that.