### PR TITLE
Pruning and Purging of stale / old fetch jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,7 @@ Then simply configure _Slurp_ to use the API key for authentication:
 ```toml
 FETCHER_COBALT_KEY = "random-uuidv4-goes-here"
 ```
+
+## Technical Details
+
+The app stores times in `UTC` - remember to convert to local timezones where required (or don't, I'm not your mom)

--- a/config.template.toml
+++ b/config.template.toml
@@ -10,6 +10,14 @@ REDIS_URL = "redis://localhost:6379/0"
 # Temporary scratch directory to write in-progress and unvalidated downloads to. Uses system default if not set.
 # OUTPUT_TEMP = "/tmp"
 
+# Purger settings - The purger has two levels, PURGE and PRUNE.
+## Purged events have their output file removed from the filesystem.
+## Purge after this many hours:
+PURGE_AFTER = 24
+## Pruned events have their logs expunged.
+## Prune after this many hours:
+PRUNE_AFTER = 168
+
 # Enable the YTDLP fetcher.
 FETCHER_YTDLP_ENABLED = true
 # Set a JavaScript runtime for YTDLP to use. This is optional, but YTDLP will run degraded if you don't set this.

--- a/slurp/__init__.py
+++ b/slurp/__init__.py
@@ -17,6 +17,7 @@ from slurp.fetchers.get_iplayer import BBCiPlayerFetcher
 from slurp.fetchers.ytdlp import YTDLPFetcher
 from slurp.helpers import format_duration
 from slurp.routes import main_blueprint
+from slurp.tasks import _init_periodic_tasks
 
 
 def __celery_init_app(app: Flask) -> Celery:
@@ -34,6 +35,9 @@ def __celery_init_app(app: Flask) -> Celery:
     celery_app.config_from_object(app.config["CELERY"])
     celery_app.set_default()
     app.extensions["celery"] = celery_app
+
+    # Bind periodic tasks
+    celery_app.on_after_configure.connect(_init_periodic_tasks)
     return celery_app
 
 

--- a/slurp/config.py
+++ b/slurp/config.py
@@ -18,6 +18,14 @@ class DefaultConfig:
     # Temporary storage directory.
     OUTPUT_TEMP: str | None = "/tmp/slurp_tmp"
 
+    # Purger settings - The purger has two levels, PURGE and PRUNE.
+    ## Purged events have their output file removed from the filesystem.
+    ## Purge after this many hours:
+    PURGE_AFTER: int = 24  # 1 day
+    ## Pruned events have their logs expunged.
+    ## Prune after this many hours:
+    PRUNE_AFTER: int = 168  # 7 days
+
     # Enable the YTDLP fetcher.
     FETCHER_YTDLP_ENABLED: bool = True
 
@@ -39,4 +47,5 @@ class DefaultConfig:
         # Message queue.
         "broker_url": REDIS_URL,
         "result_backend": REDIS_URL,
+        "task_ignore_result": True,
     }

--- a/slurp/models/base.py
+++ b/slurp/models/base.py
@@ -13,6 +13,10 @@ class BaseModel(JsonModel):
     ts_created: datetime = Field(sortable=True, default=datetime.now(timezone.utc))
     ts_updated: datetime = Field(sortable=True, default=datetime.now(timezone.utc))
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ts_created = datetime.now(timezone.utc)
+
     def save(self, **kwargs):
         self.ts_updated = datetime.now(timezone.utc)
         super().save(**kwargs)

--- a/slurp/models/base.py
+++ b/slurp/models/base.py
@@ -10,7 +10,10 @@ class BaseModel(JsonModel):
     Base model
     """
 
-    ts_created: datetime = Field(sortable=True, default=datetime.now(timezone.utc))
+    ts_created: datetime = Field(
+        sortable=True,
+        default_factory=datetime.now(timezone.utc).now,
+    )
     ts_updated: datetime = Field(sortable=True, default=datetime.now(timezone.utc))
 
     def save(self, **kwargs):

--- a/slurp/models/base.py
+++ b/slurp/models/base.py
@@ -13,10 +13,6 @@ class BaseModel(JsonModel):
     ts_created: datetime = Field(sortable=True, default=datetime.now(timezone.utc))
     ts_updated: datetime = Field(sortable=True, default=datetime.now(timezone.utc))
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ts_created = datetime.now(timezone.utc)
-
     def save(self, **kwargs):
         self.ts_updated = datetime.now(timezone.utc)
         super().save(**kwargs)

--- a/slurp/models/task.py
+++ b/slurp/models/task.py
@@ -1,6 +1,7 @@
 import datetime
 import enum
 
+from flask_sse import sse
 from redis_om import Field
 
 from slurp.fetchers.types import Format
@@ -51,8 +52,29 @@ class Fetch(BaseModel, index=True):
     # The ID of the celery task.
     worker_id: str | None = Field(index=True, default=None)
 
+    # The path to the output file - only set if the fetch succeeded.
+    # If pruned is set, this path most likely does not exist, and is for information only.
+    output_path: str | None = None
+
+    # Whether this fetch has had its output data removed from the filesystem.
+    pruned: bool = Field(index=True, default=False)
+
+    # Whether this fetch has had its logs and events destroyed.
+    purged: bool = Field(index=True, default=False)
+
     def lock(self):
         return self.db().lock(name=self.pk)
+
+    def emit_event(self, typ: str, level: str, message: str, status: int = 0):
+        db_log = FetchEvent(
+            fetch_id=self.pk,
+            typ=typ,
+            level=level,
+            message=message,
+            status=status,
+        )
+        db_log.save()
+        sse.publish(db_log.model_dump_json())
 
 
 class FetchEvent(BaseModel, index=True):

--- a/slurp/routes.py
+++ b/slurp/routes.py
@@ -36,7 +36,7 @@ main_blueprint = Blueprint("main", __name__, template_folder="templates")
 def index():
     form = DownloadForm(request.args)
     form.target.choices = current_app.config["OUTPUTS"]
-    allTasks = Fetch.find().sort_by("-ts_updated").page(offset=0, limit=10)
+    allTasks = Fetch.find().sort_by("-ts_created").page(offset=0, limit=10)
 
     return render_template(
         "index.html", form=form, fetchers=fetchers, allTasks=allTasks

--- a/slurp/tasks.py
+++ b/slurp/tasks.py
@@ -187,7 +187,7 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                     "state": Fetch.TaskStatus.failed.value,
                     "message": str(e),
                 },
-                type="status",
+                type="fetch_updated",
             )
             task.emit_event(
                 "log",
@@ -207,7 +207,7 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                 "state": Fetch.TaskStatus.success.value,
                 "path": final_path,
             },
-            type="status",
+            type="fetch_updated",
         )
         task.emit_event(
             "log",

--- a/slurp/tasks.py
+++ b/slurp/tasks.py
@@ -1,6 +1,10 @@
+import datetime
+import pathlib
 import tempfile
 
-from celery import Task, shared_task
+from celery import Celery, Task, shared_task
+from celery.exceptions import InvalidTaskError
+from celery.schedules import crontab
 from flask import current_app
 from flask_sse import sse
 from werkzeug.exceptions import BadRequest
@@ -46,6 +50,8 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
         target=target,
         slug=slug,
     )
+    # This assertion is mainly here to clear some IDE warnings.
+    assert task.target is not None, "task target must be set"
     task.status = Fetch.TaskStatus.running
     task.worker_id = self.request.id
     task.save()
@@ -53,18 +59,6 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
     lock = task.lock()
     try:
         lock.acquire(token=self.request.id)
-
-        def raiseFetchEvent(typ: str, level: str, message: str, status: int = 0):
-            db_log = FetchEvent(
-                fetch_id=task.pk,
-                typ=typ,
-                level=level,
-                message=message,
-                status=status,
-            )
-            db_log.save()
-            self.update_state(event=db_log.model_dump_json())
-            sse.publish(db_log.model_dump_json())
 
         sse.publish(
             {
@@ -76,7 +70,7 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
             },
             type="created_data",
         )
-        raiseFetchEvent("created", "info", f"Running task {task.pk}")
+        task.emit_event("created", "info", f"Running task {task.pk}")
 
         # Perform the fetch.
         # yield from stream_fetch(
@@ -105,7 +99,7 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                         },
                         type="message",
                     )
-                    raiseFetchEvent(
+                    task.emit_event(
                         "log",
                         "info",
                         f"{'Trying Fetch again' if idx > 0 else 'Fetching'} with {fetcher.name}",
@@ -135,7 +129,7 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                                     },
                                     type="metadata",
                                 )
-                                raiseFetchEvent(
+                                task.emit_event(
                                     "log",
                                     "info",
                                     "Metadata successfully fetched",
@@ -144,14 +138,14 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                                 media_path = e.path
                             case FetcherProgressReport() as e:
                                 self.update_state(event=e)
-                                raiseFetchEvent(e.typ, e.level, e.message, e.status)
+                                task.emit_event(e.typ, e.level, e.message, e.status)
 
                                 if e.typ == "finish":
                                     if e.status == 0:
                                         # Success
                                         success = True
                                     else:
-                                        raiseFetchEvent(
+                                        task.emit_event(
                                             "log",
                                             "error",
                                             f"Fetcher failed: {e.message}",
@@ -164,6 +158,10 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                     # yield "<article class='fetcher-outcome fetcher-progress-message-level-error'>☹️ Slurp failed - out of available fetchers.</article>"
                     raise FetchersExhaustedError
 
+                assert media_path is not None, (
+                    "fetcher reported success yet media_path is None"
+                )
+
                 # Run the finaliser.
                 self.update_state(event="Finalising...")
                 final_path: str | None = None
@@ -172,7 +170,7 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                         match event:
                             case FetcherProgressReport() as e:
                                 self.update_state(event=e)
-                                raiseFetchEvent(e.typ, e.level, e.message, e.status)
+                                task.emit_event(e.typ, e.level, e.message, e.status)
                             case FetcherMediaAvailable() as e:
                                 final_path = e.path
                 except Exception as e:
@@ -191,15 +189,17 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                 },
                 type="status",
             )
-            raiseFetchEvent(
+            task.emit_event(
                 "log",
                 "error",
                 f"Fetch failed: {e}",
             )
             raise e
 
+        assert final_path is not None, "final_path not properly set by fetcher routine"
         self.update_state(status=Fetch.TaskStatus.success.value, path=final_path)
-        task.status = Fetch.TaskStatus.success
+        task.status = Fetch.TaskStatus.success.value
+        task.output_path = final_path
         task.save()
         sse.publish(
             {
@@ -209,7 +209,7 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
             },
             type="status",
         )
-        raiseFetchEvent(
+        task.emit_event(
             "log",
             "success",
             f"Fetch succeeded: file saved to {final_path}",
@@ -219,3 +219,87 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
     finally:
         # Always release the lock to avoid a deadlock.
         lock.release()
+
+
+@shared_task(bind=True, ignore_result=False)
+def cleanup_stale_tasks(self):
+    """
+    cleanup_stale_tasks removes persistent data about tasks that exceed the configured TASK_STALE duration.
+    :param self:
+    :return:
+    """
+    # Get the timestamp of the desired cutoffs.
+    # TODO configurable
+    # The PRUNE cutoff simply destroys the output data blob.
+    prune_cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+        hours=current_app.config.get("PRUNE_AFTER")
+    )
+    # The PURGE cutoff destroys all event data, leaving only the metadata.
+    purge_cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+        hours=current_app.config.get("PURGE_AFTER")
+    )
+
+    # Find all tasks that are OLDER than the cutoff, and that have not been purged.
+    # Purged is done as a negative to catch models without the key set
+    prune_targets = Fetch.find(
+        (Fetch.ts_created <= prune_cutoff) & ~(Fetch.purged == True),  # noqa: E712
+    ).all()
+    for task in prune_targets:
+        # Enqueue cleanup
+        # Could do this shorthand however it's (IMO) easier to read this way
+        if task.ts_created < purge_cutoff:
+            # PURGE the task.
+            cleanup_task.delay(task.pk, events=True)
+        else:
+            # PRUNE the task.
+            cleanup_task.delay(task.pk, events=False)
+    ids = [t.pk for t in prune_targets]
+    return ids
+
+
+@shared_task(bind=True)
+def cleanup_task(self, task_pk: str, events: bool = False):
+    """
+    cleanup_task removes data about the given task from the database, and attempts to remove any files related to the fetch.
+    :param self:
+    :param task_pk: ID of the task.
+    :param events: Destroy all logs and events relating to this task. This is a PURGE.
+    :return:
+    """
+    task = Fetch.find(Fetch.pk == task_pk).first()
+    if not task:
+        raise InvalidTaskError(f"Task {task_pk} does not exist on database")
+
+    # Destroy any events relating to the task if requested
+    if events:
+        FetchEvent.find(FetchEvent.fetch_id == task_pk).delete()
+        task.purged = True
+
+    # Destroy the resultant file in the filesystem, if it's there
+    if task.output_path is not None:
+        fs_target = pathlib.Path(task.output_path)
+        if fs_target.is_file():
+            fs_target.unlink()
+        else:
+            print("Failed to destroy output - does not exist, or is not a file")
+    # Mark the task as pruned
+    task.pruned = True
+    task.save()
+
+    # Raise SSE event / add to the log that the prune occurred
+    task.emit_event(
+        ("purge" if events else "prune"),
+        "info",
+        f"Task was {'purged' if events else 'pruned'}",
+        0,
+    )
+    return
+
+
+def _init_periodic_tasks(sender: Celery, **kwargs):
+    # Clean up stale tasks every hour.
+    sender.add_periodic_task(
+        # Run hourly, on the hour.
+        crontab(minute=0),
+        cleanup_stale_tasks.s(),
+    )

--- a/slurp/tasks.py
+++ b/slurp/tasks.py
@@ -26,7 +26,7 @@ from slurp.models import Fetch, FetchMetadata
 from slurp.models.task import FetchEvent
 
 
-@shared_task(bind=True, dont_autoretry_for=(BadRequest,))
+@shared_task(bind=True, dont_autoretry_for=(BadRequest,), acks_late=True)
 def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
     """
     Fetch the given media from the network.
@@ -226,10 +226,9 @@ def cleanup_stale_tasks(self):
     """
     cleanup_stale_tasks removes persistent data about tasks that exceed the configured TASK_STALE duration.
     :param self:
-    :return:
+    :return: A list of IDs affected by the task
     """
     # Get the timestamp of the desired cutoffs.
-    # TODO configurable
     # The PRUNE cutoff simply destroys the output data blob.
     prune_cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
         hours=current_app.config.get("PRUNE_AFTER")

--- a/slurp/templates/_base.html
+++ b/slurp/templates/_base.html
@@ -34,24 +34,41 @@
             opacity: 0.8;
         }
 
-        .fetcher-progress-message {
-            display: block;
-            padding: .2em .375em;
+        div.fetcher-log-container {
+            border: 2px #666666 solid;
+            padding: 1em;
         }
 
-        .fetcher-progress-message-level-error {
+        div.fetcher-log-container div.fetcher-log-entry {
+            display: flex;
+            flex-wrap: wrap;
+            border-radius: 2em 0 0 2em;
+            background: #222222;
+        }
+
+        div.fetcher-log-container div.log-ts {
+            margin: 0.2em;
+        }
+
+        div.fetcher-log-container div.log-entry {
+            flex-grow: 1;
+            flex-shrink: 1;
+            margin: 0.2em;
+        }
+
+        .message-level-error {
             color: red;
         }
 
-        .fetcher-progress-message-level-warning {
+        .message-level-warning {
             color: goldenrod;
         }
 
-        .fetcher-progress-message-level-info {
+        .message-level-info {
             color: lightskyblue;
         }
 
-        .fetcher-progress-message-level-success {
+        .message-level-success {
             color: green;
         }
 

--- a/slurp/templates/fetch.html
+++ b/slurp/templates/fetch.html
@@ -21,30 +21,33 @@
             <span>This task has been <b>PRUNED</b> - output data has been destroyed.</span>
         {% endif %}
     {% endif %}
-    <section id="fetcher-log" class="fetcher-progress-log">
+    <article class="fetcher-progress-log">
         <h3>Fetch Log:</h3>
-        {% for data in fetchLog %}
-            <div class="fetcher-progress-message">
-                {% if data.typ == "created" %}
-                    <div class="fetcher-progress-message-level-success">🛫 Fetch job started
-                        at {{ data.ts_created }}</div>
-                {% elif data.typ == "log" %}
-                    <div class="fetcher-progress-message-level-{{ data.level }}">
-                        {% if data.level == "error" %}
-                            ⚠️ {{ data.message | safe }}
-                        {% else %}
-                            → {{ data.message | safe }}
-                        {% endif %}
-                    </div>
-                {% elif data.typ == "purge" %}
-                    <div class="fetcher-progress-message-level-error">{{ data.message | safe }}</div>
-                {% else %}
-                    <div class="fetcher-progress-message-level-info">{{ data.message | safe }}</div>
-                {% endif %}
+        <div class="fetcher-log-container" id="fetcher-log">
+            {% for data in fetchLog %}
+                <div class="fetcher-log-entry">
+                    <div class="log-ts">{{ data.ts_created.strftime('%Y/%m/%d %H:%M:%S') }}</div>
+                    {% if data.typ == "created" %}
+                        <div class="log-entry message-level-success">🛫 Fetch job started
+                            at {{ data.ts_created.strftime('%Y/%m/%d %H:%M:%S') }}</div>
+                    {% elif data.typ == "log" %}
+                        <div class="log-entry message-level-{{ data.level }}">
+                            {% if data.level == "error" %}
+                                ⚠️ {{ data.message | safe }}
+                            {% else %}
+                                → {{ data.message | safe }}
+                            {% endif %}
+                        </div>
+                    {% elif data.typ == "purge" %}
+                        <div class="log-entry message-level-error">{{ data.message | safe }}</div>
+                    {% else %}
+                        <div class="log-entry message-level-info">{{ data.message | safe }}</div>
+                    {% endif %}
+                </div>
+            {% endfor %}
+        </div>
 
-            </div>
-        {% endfor %}
-    </section>
+    </article>
 {% endblock %}
 
 {% block tail %}
@@ -58,15 +61,32 @@
 
 {% block script %}
     <script>
+        // This is entirely hot garbage. Please replace me with a proper client side rendering framework
+        // like vue.js or React or something plz it burns
+        function format_ts(ts) {
+            const m = new Date(ts)
+            // thank you, JS
+            return m.getUTCFullYear() + "/" +
+                ("0" + (m.getUTCMonth() + 1)).slice(-2) + "/" +
+                ("0" + m.getUTCDate()).slice(-2) + " " +
+                ("0" + m.getUTCHours()).slice(-2) + ":" +
+                ("0" + m.getUTCMinutes()).slice(-2) + ":" +
+                ("0" + m.getUTCSeconds()).slice(-2);
+        }
+
         var source = new EventSource("{{ url_for('sse.stream') }}");
         const eventList = document.getElementById("fetcher-log");
         source.addEventListener('created_data', function (event) {
             var data = JSON.parse(event.data);
             console.log("created", data);
             const l = document.createElement("div")
-            l.classList = "fetcher-progress-message"
+            l.classList = "fetcher-log-entry"
+            const li_ts = document.createElement("div")
+            li_ts.classList = "log-ts"
+            li_ts.textContent = format_ts(data.ts_created)
+            l.appendChild(li_ts)
             const li = document.createElement("div")
-            li.classList = "fetcher-progress-message-level-" + data.level
+            li.classList = "log-entry message-level-" + data.level
             li.textContent = data
             l.appendChild(li)
             eventList.appendChild(l)
@@ -75,9 +95,13 @@
             var data = JSON.parse(event.data);
             console.log("message", data);
             const l = document.createElement("div")
-            l.classList = "fetcher-progress-message"
+            l.classList = "fetcher-log-entry"
+            const li_ts = document.createElement("div")
+            li_ts.classList = "log-ts"
+            li_ts.textContent = format_ts(data.ts_created)
+            l.appendChild(li_ts)
             const li = document.createElement("div")
-            li.classList = "fetcher-progress-message-level-" + data.level
+            li.classList = "log-entry message-level-" + data.level
             const jewel = (data.level !== 'error') ? "→" : "⚠️";
             li.textContent = jewel + " " + data.message
             l.appendChild(li)
@@ -87,9 +111,13 @@
             var data = JSON.parse(event.data);
             console.log("status", data);
             const l = document.createElement("div")
-            l.classList = "fetcher-progress-message"
+            l.classList = "fetcher-log-entry"
+            const li_ts = document.createElement("div")
+            li_ts.classList = "log-ts"
+            li_ts.textContent = format_ts(data.ts_created)
+            l.appendChild(li_ts)
             const li = document.createElement("div")
-            li.classList = "fetcher-progress-message-level-" + data.level
+            li.classList = "log-entry message-level-" + data.level
             li.textContent = data.message
             l.appendChild(li)
             eventList.appendChild(l)
@@ -99,7 +127,7 @@
             console.log(data);
         };
         source.addEventListener('error', function (event) {
-            alert("Failed to connect to the Slurp backend.");
+            alert("Lost connection to Slurp - please refresh.");
         }, false);
     </script>
 {% endblock %}

--- a/slurp/templates/fetch.html
+++ b/slurp/templates/fetch.html
@@ -8,12 +8,19 @@
         });
         resizeObserver.observe(document.body);
     </script>
-    <h1>Slug <kbd>🐌{{ fetch.slug }}</kbd></h1>
+    <h1>Slug <kbd>🐌{{ fetch.slug }}</kbd> {{ fetch.status.value }}</h1>
     <h2>Job ID <code title="{{ fetch.pk }}">🥤{{ fetch.pk[-4:] }}</code></h2>
     <h3>📆 Created {{ fetch.ts_created.strftime('%Y-%m-%d %H:%M') }}</h3>
 
     {% include "elements/media.html" %}
 
+    {% if fetch.pruned %}
+        {% if fetch.purged %}
+            <span>This task has been <b>PURGED</b> - output data and logs are not available.</span>
+        {% else %}
+            <span>This task has been <b>PRUNED</b> - output data has been destroyed.</span>
+        {% endif %}
+    {% endif %}
     <section id="fetcher-log" class="fetcher-progress-log">
         <h3>Fetch Log:</h3>
         {% for data in fetchLog %}
@@ -29,7 +36,12 @@
                             → {{ data.message | safe }}
                         {% endif %}
                     </div>
+                {% elif data.typ == "purge" %}
+                    <div class="fetcher-progress-message-level-error">{{ data.message | safe }}</div>
+                {% else %}
+                    <div class="fetcher-progress-message-level-info">{{ data.message | safe }}</div>
                 {% endif %}
+
             </div>
         {% endfor %}
     </section>

--- a/slurp/templates/index.html
+++ b/slurp/templates/index.html
@@ -45,16 +45,27 @@
                 <li>
                     <a href="{{ url_for('main.fetch_info', id=task.pk) }}"><b><kbd>🐌{{ task.slug }}</kbd></b></a>
                     <code title="Job ID: {{ task.pk }}">🥤{{ task.pk[-4:] }}</code>
-
+                    <a href="{{ url_for('main.fetch_info', id=task.pk) }}">👀 Details...</a>
                     <ul>
-                        <li>📆 Created {{ task.ts_created.strftime('%Y-%m-%d %H:%M') }}</li>
-                        <li>🌐 {{ task.url }}</li>
-                        <li>✈️ Task <b>{{ task.status.value }}</b></li>
-                        <li><a href="{{ url_for('main.fetch_info', id=task.pk) }}">👀 Fetch Details...</a></li>
+                        {% if task.purged %}
+                            <li>
+                                <i>🪓 {{ task.status.value }} task <b>PURGED</b> due to age</i>
+                            </li>
+                        {% else %}
+                            {% if task.pruned %}
+                                <li>✂️ <b>PRUNED</b> (output file removed)</li>
+                            {% endif %}
+                            <li>📆 Created {{ task.ts_created.strftime('%Y-%m-%d %H:%M') }}</li>
+                            <li>🌐 {{ task.url }}</li>
+                            <li>✈️ Task <b>{{ task.status.value }}</b></li>
+                        {% endif %}
                     </ul>
                 </li>
             {% endfor %}
         </ul>
+    </article>
+    <article style="text-align: center">Slurps will be pruned after {{ config.PRUNE_AFTER }} hours, and purged
+        after {{ config.PURGE_AFTER }} hours
     </article>
 {% endblock %}
 

--- a/slurp/templates/index.html
+++ b/slurp/templates/index.html
@@ -64,8 +64,13 @@
             {% endfor %}
         </ul>
     </article>
-    <article style="text-align: center">Slurps will be pruned after {{ config.PRUNE_AFTER }} hours, and purged
-        after {{ config.PURGE_AFTER }} hours
+    <article style="text-align: center">
+        <p>
+            Slurps will be pruned after {{ config.PRUNE_AFTER }} hours, and purged after {{ config.PURGE_AFTER }} hours.
+        </p>
+        <p>
+            All timestamps displayed are in UTC unless otherwise specified.
+        </p>
     </article>
 {% endblock %}
 


### PR DESCRIPTION
This PR adds "pruning" and "purging".

"Pruning" a slurp involves destroying its output data (if it's still there).

"Purging" a slurp destroys its logs, leaving only the metadata about the run (and also prunes it).

By default, pruning is set to 24 hours, and purging is set to 7 days. These are configurable.

Closes #10 