### PR TITLE
Move the creation of the fetch to a separate task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           redis-version: "7.4"
 
       - name: Run tests
-        run: uv run pytest -v
+        run: uv run pytest -v -m 'not dl'
 
   lint:
     runs-on: ubuntu-latest

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,24 @@
+"""
+conftest.py defines the fixtures and settings that pytest uses when running the test suite.
+"""
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-huge-dl",
+        action="store_true",
+        default=False,
+        help="run tests with huge download implications",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-huge-dl"):
+        # --run-huge-dl given in cli: do not skip slow tests
+        return
+    skip_huge = pytest.mark.skip(reason="skipping huge download")
+    for item in items:
+        if "huge_dl" in item.keywords:
+            item.add_marker(skip_huge)

--- a/deploy/cri/bin/start-celeryworker
+++ b/deploy/cri/bin/start-celeryworker
@@ -3,4 +3,5 @@
 set -o errexit
 set -o nounset
 
-celery -A slurp.make_celery:celery  worker -l info
+# This could do with being configurable (so you can have a worker dedicated to fetch tasks)
+celery -A slurp.make_celery:celery worker -l info -Q celery,fetch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,6 @@ namespace = true
 [build-system]
 requires = ["uv_build>=0.9.22,<0.12.0"]
 build-backend = "uv_build"
+
+[pytest]
+tmp_path_retention_policy = "none"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    huge_dl: marks tests as requiring an enormous download (opt-in with '--run-huge-dl')
     network: marks tests as requiring internet connectivity

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
-    slow: marks tests as slow (deselect with '-m "not slow"')
-    huge_dl: marks tests as requiring an enormous download (opt-in with '--run-huge-dl')
+    slow: marks tests as slow (opt-out with '-m "not slow"')
     network: marks tests as requiring internet connectivity
+    dl: marks tests as requiring a download to the filesystem of some kind (opt-out with '-m "not dl"')
+    huge_dl: marks tests as requiring an enormous download (opt-in with '--run-huge-dl')

--- a/slurp/__init__.py
+++ b/slurp/__init__.py
@@ -36,6 +36,12 @@ def __celery_init_app(app: Flask) -> Celery:
     celery_app.set_default()
     app.extensions["celery"] = celery_app
 
+    # Create task routes
+    celery_app.conf.task_routes = {
+        # Fetch tasks should take place in their own queue, as they can be quite lengthy.
+        "slurp.fetch": {"queue": "fetch"}
+    }
+
     # Bind periodic tasks
     celery_app.on_after_configure.connect(_init_periodic_tasks)
     return celery_app

--- a/slurp/api/fetchtasks.py
+++ b/slurp/api/fetchtasks.py
@@ -137,8 +137,7 @@ class List(Resource):
                 slug=data.slug,
             )
             # Await the result from the worker.
-            result.get()
-            return {"fetch_id": result}, 201
+            return {"fetch_id": result.get()}, 201
             # return {"message": "Task created", "data": data.model_dump()}, 200
 
         except ValidationError as e:

--- a/slurp/api/fetchtasks.py
+++ b/slurp/api/fetchtasks.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, BeforeValidator, Field, field_serializer
 
 from slurp.fetchers.types import Format
 from slurp.models.task import Fetch
-from slurp.tasks import fetch
+from slurp.tasks import create_fetch
 
 api = Namespace("task", description="Fetch tasks")
 
@@ -129,14 +129,16 @@ class List(Resource):
                     "error": "This target is not valid. Please refer to Slurp's configuration."
                 }, 400
 
-            # Request that the fetch be worked on by the task queue.
-            result = fetch.delay(
+            # Create the fetch - it is automatically worked on by the task queue.
+            result = create_fetch.delay(
                 url=data.url,
-                format=data.format,
+                fmt=data.format,
                 target=data.target,
                 slug=data.slug,
             )
-            return {"worker_id": result.id}, 201
+            # Await the result from the worker.
+            result.get()
+            return {"fetch_id": result}, 201
             # return {"message": "Task created", "data": data.model_dump()}, 200
 
         except ValidationError as e:
@@ -148,5 +150,5 @@ class Work(Resource):
     @api.doc("get_task_by_worker")
     @api.marshal_with(fetchTask)
     def get(self, worker_id):
-        fetch = Fetch.find(worker_id == worker_id).first()
-        return fetch
+        fetch_obj = Fetch.find(worker_id == worker_id).first()
+        return fetch_obj

--- a/slurp/fetchers/exceptions.py
+++ b/slurp/fetchers/exceptions.py
@@ -18,3 +18,8 @@ class NoFetchersAvailable(Exception):
 class FetchersExhaustedError(Exception):
     def __str__(self):
         return "Available Fetchers exhausted"
+
+
+class FetchLockedError(Exception):
+    def __str__(self):
+        return "Fetch locked by another worker"

--- a/slurp/fetchers/test_ytdlp.py
+++ b/slurp/fetchers/test_ytdlp.py
@@ -1,0 +1,52 @@
+import httpx
+import pytest
+
+from slurp import YTDLPFetcher
+from slurp.fetchers.types import Format
+
+_urls = {
+    "small": "https://www.youtube.com/watch?v=eVrYbKBrI7o",  # toot
+    "huge": "https://www.youtube.com/watch?v=mSX3OyW9Rao",  # 8 hours roaring fire
+}
+
+
+def __can_contact_youtube() -> bool:
+    try:
+        httpx.get("https://youtube.com")
+    except (httpx.RequestError, httpx.ConnectError):
+        return False
+    return True
+
+
+@pytest.mark.skipif(not __can_contact_youtube(), reason="Cannot contact YouTube")
+class TestYTDLPFetcher:
+    @pytest.fixture
+    def fetcher_instance(self):
+        return YTDLPFetcher()
+
+    @pytest.mark.network
+    def test_get_metadata(self, fetcher_instance):
+        meta = fetcher_instance._get_metadata(_urls["huge"])
+        assert meta is not None, "_get_metadata returned None"
+
+    def test_download(self, tmp_path, fetcher_instance):
+        for event in fetcher_instance.fetch(
+            _urls["small"], Format.VIDEO_AUDIO, str(tmp_path.absolute()), "test"
+        ):
+            print(event)
+        assert (tmp_path / "test.webm").exists(), (
+            "output file does not exist (expected 'test.webm')"
+        )
+
+    @pytest.mark.huge
+    def test_huge_download(self, tmp_path, fetcher_instance):
+        """
+        Warning: this test downloads an enormous video with a huge filesize!
+        """
+        for event in fetcher_instance.fetch(
+            _urls["huge"], Format.VIDEO_AUDIO, str(tmp_path.absolute()), "test"
+        ):
+            print(event)
+        assert (tmp_path / "test.webm").exists(), (
+            "output file does not exist (expected 'test.webm')"
+        )

--- a/slurp/fetchers/test_ytdlp.py
+++ b/slurp/fetchers/test_ytdlp.py
@@ -1,5 +1,6 @@
 import httpx
 import pytest
+import yt_dlp.utils
 
 from slurp import YTDLPFetcher
 from slurp.fetchers.types import Format
@@ -19,6 +20,10 @@ def __can_contact_youtube() -> bool:
 
 
 @pytest.mark.skipif(not __can_contact_youtube(), reason="Cannot contact YouTube")
+@pytest.mark.xfail(
+    raises=yt_dlp.utils.DownloadError,
+    reason="Bot detection can cause these tests to fail",
+)
 class TestYTDLPFetcher:
     @pytest.fixture
     def fetcher_instance(self):

--- a/slurp/fetchers/test_ytdlp.py
+++ b/slurp/fetchers/test_ytdlp.py
@@ -29,6 +29,7 @@ class TestYTDLPFetcher:
         meta = fetcher_instance._get_metadata(_urls["huge"])
         assert meta is not None, "_get_metadata returned None"
 
+    @pytest.mark.network
     def test_download(self, tmp_path, fetcher_instance):
         for event in fetcher_instance.fetch(
             _urls["small"], Format.VIDEO_AUDIO, str(tmp_path.absolute()), "test"
@@ -38,10 +39,12 @@ class TestYTDLPFetcher:
             "output file does not exist (expected 'test.webm')"
         )
 
-    @pytest.mark.huge
+    @pytest.mark.network
+    @pytest.mark.huge_dl
     def test_huge_download(self, tmp_path, fetcher_instance):
         """
         Warning: this test downloads an enormous video with a huge filesize!
+        It is intended purely as a stress test.
         """
         for event in fetcher_instance.fetch(
             _urls["huge"], Format.VIDEO_AUDIO, str(tmp_path.absolute()), "test"

--- a/slurp/fetchers/test_ytdlp.py
+++ b/slurp/fetchers/test_ytdlp.py
@@ -30,6 +30,7 @@ class TestYTDLPFetcher:
         assert meta is not None, "_get_metadata returned None"
 
     @pytest.mark.network
+    @pytest.mark.dl
     def test_download(self, tmp_path, fetcher_instance):
         for event in fetcher_instance.fetch(
             _urls["small"], Format.VIDEO_AUDIO, str(tmp_path.absolute()), "test"
@@ -40,6 +41,7 @@ class TestYTDLPFetcher:
         )
 
     @pytest.mark.network
+    @pytest.mark.dl
     @pytest.mark.huge_dl
     def test_huge_download(self, tmp_path, fetcher_instance):
         """

--- a/slurp/models/task.py
+++ b/slurp/models/task.py
@@ -62,8 +62,8 @@ class Fetch(BaseModel, index=True):
     # Whether this fetch has had its logs and events destroyed.
     purged: bool = Field(index=True, default=False)
 
-    def lock(self):
-        return self.db().lock(name=self.pk)
+    def lock(self, *args, **kwargs):
+        return self.db().lock(name=self.pk, *args, **kwargs)
 
     def emit_event(self, typ: str, level: str, message: str, status: int = 0):
         db_log = FetchEvent(

--- a/slurp/tasks.py
+++ b/slurp/tasks.py
@@ -13,31 +13,30 @@ from slurp.exceptions import FinaliserError
 from slurp.fetchers import fetchers_for_url
 from slurp.fetchers.exceptions import (
     FetchersExhaustedError,
+    FetchLockedError,
     NoFetchersAvailable,
 )
 from slurp.fetchers.types import (
     FetcherMediaAvailable,
     FetcherMediaMetadataAvailable,
     FetcherProgressReport,
-    Format,
 )
 from slurp.finaliser import finalise
 from slurp.models import Fetch, FetchMetadata
 from slurp.models.task import FetchEvent
 
 
-@shared_task(bind=True, dont_autoretry_for=(BadRequest,), acks_late=True)
-def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
+@shared_task(bind=True, dont_autoretry_for=(BadRequest,), ignore_result=False)
+def create_fetch(self: Task, url: str, fmt: str, target: str, slug: str) -> str:
     """
-    Fetch the given media from the network.
+    Create and enqueue the given media for fetching.
     :param self: Celery task object.
     :param url: Target URL.
-    :param format: Format to perform the download in.
+    :param fmt: Format to perform the download in as defined by fetchers.types.Format.
     :param target: Target output directory. Must be configured.
     :param slug: Output filename.
-    :return: Absolute path to where the successfully fetched media resides.
+    :return: Fetch PK.
     """
-
     # Safety: Validate the destination is permitted
     if target not in current_app.config["OUTPUTS"]:
         raise BadRequest(
@@ -46,37 +45,74 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
 
     task = Fetch(
         url=url,
-        format=format,
+        format=fmt,
         target=target,
         slug=slug,
     )
-    # This assertion is mainly here to clear some IDE warnings.
-    assert task.target is not None, "task target must be set"
-    task.status = Fetch.TaskStatus.running
+    task.status = Fetch.TaskStatus.created
     task.worker_id = self.request.id
     task.save()
+    assert task.pk is not None, "task pk was not set by flush"
 
-    lock = task.lock()
-    try:
-        lock.acquire(token=self.request.id)
+    sse.publish(
+        {
+            "task_id": task.pk,
+            "url": task.url,
+            "format": task.format,
+            "target": task.target,
+            "slug": task.slug,
+        },
+        type="task_created",
+    )
 
-        sse.publish(
-            {
-                "task_id": task.pk,
-                "url": task.url,
-                "format": format,
-                "target": target,
-                "slug": slug,
-            },
-            type="created_data",
+    # Enqueue.
+    fetch.delay(
+        pk=task.pk,
+    )
+    return task.pk
+
+
+@shared_task(bind=True, dont_autoretry_for=(BadRequest,), acks_late=True)
+def fetch(self: Task, pk: str):
+    """
+    Work the given fetch task, by downloading the media from the web, finalising it to the defined location.
+    It is not intended to call this task directly - it is automatically enqueued by create_fetch.
+    :param self: Celery task object.
+    :param pk: Primary Key of the task in the database.
+    :return: None
+    """
+
+    task = Fetch.find(Fetch.pk == pk).first()
+    if not task:
+        raise BadRequest(f"Task {pk} does not exist on database")
+
+    # This assertion is mainly here to clear some IDE warnings.
+    assert task.target is not None, "task target must be set"
+
+    # Re-validate that the destination is permitted for extra safety - just in case the database has been tampered with
+    if task.target not in current_app.config["OUTPUTS"]:
+        raise BadRequest(
+            "This target is not valid. Please refer to Slurp's configuration."
         )
-        task.emit_event("created", "info", f"Running task {task.pk}")
 
-        # Perform the fetch.
-        # yield from stream_fetch(
-        #     url=task.url, format=task.format, target=task.target, slug=task.slug
-        # )
+    # We take a lock to ensure that we're the only thing working with the given Fetch.
+    # If multiple workers were working the same fetch, not only is it a waste of resources, but
+    # there's a very real possibility they may end up corrupting
+    # the output file once it's written to disk.
+    lock = task.lock(blocking=False)
+    try:
+        l_success = lock.acquire(token=self.request.id)
+        if not l_success:
+            raise FetchLockedError
+
+        # Update the task status
+        task.status = Fetch.TaskStatus.running
+        task.worker_id = self.request.id
+        task.save()
+        task.emit_event("log", "info", f"Task acquired by job {self.request.id}")
+
         try:
+            # Find all fetchers valid for the fetch URL
             fetchers = fetchers_for_url(task.url)
             if len(fetchers) == 0:
                 raise NoFetchersAvailable
@@ -104,6 +140,7 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                         "info",
                         f"{'Trying Fetch again' if idx > 0 else 'Fetching'} with {fetcher.name}",
                     )
+                    # Call the fetcher module, and receive events from it
                     for event in fetcher.fetch(
                         task.url, task.format, tmp_dir, task.slug
                     ):
@@ -158,12 +195,13 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                     # yield "<article class='fetcher-outcome fetcher-progress-message-level-error'>☹️ Slurp failed - out of available fetchers.</article>"
                     raise FetchersExhaustedError
 
+                # Safety assertion
                 assert media_path is not None, (
                     "fetcher reported success yet media_path is None"
                 )
 
-                # Run the finaliser.
-                self.update_state(event="Finalising...")
+                # The fetcher seems to have worked - run the finaliser.
+                self.update_state(event="finalising")
                 final_path: str | None = None
                 try:
                     for event in finalise(media_path, task.target):
@@ -178,6 +216,7 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
                     raise FinaliserError(e)
                 # yield f"<article class='fetcher-outcome fetcher-progress-message-level-success'>🥤 Media slurped to {final_path}</article>"
         except Exception as e:
+            # Catch exceptions and set the task state appropriately.
             self.update_state(status=Fetch.TaskStatus.failed.value, reason=str(e))
             task.status = Fetch.TaskStatus.failed
             task.save()
@@ -197,6 +236,7 @@ def fetch(self: Task, url: str, format: Format, target: str, slug: str) -> str:
             raise e
 
         assert final_path is not None, "final_path not properly set by fetcher routine"
+        # Update the fetch with the final state.
         self.update_state(status=Fetch.TaskStatus.success.value, path=final_path)
         task.status = Fetch.TaskStatus.success.value
         task.output_path = final_path

--- a/slurp/tasks.py
+++ b/slurp/tasks.py
@@ -26,7 +26,12 @@ from slurp.models import Fetch, FetchMetadata
 from slurp.models.task import FetchEvent
 
 
-@shared_task(bind=True, dont_autoretry_for=(BadRequest,), ignore_result=False)
+@shared_task(
+    name="slurp.create_fetch",
+    bind=True,
+    dont_autoretry_for=(BadRequest,),
+    ignore_result=False,
+)
 def create_fetch(self: Task, url: str, fmt: str, target: str, slug: str) -> str:
     """
     Create and enqueue the given media for fetching.
@@ -72,7 +77,9 @@ def create_fetch(self: Task, url: str, fmt: str, target: str, slug: str) -> str:
     return task.pk
 
 
-@shared_task(bind=True, dont_autoretry_for=(BadRequest,), acks_late=True)
+@shared_task(
+    name="slurp.fetch", bind=True, dont_autoretry_for=(BadRequest,), acks_late=True
+)
 def fetch(self: Task, pk: str):
     """
     Work the given fetch task, by downloading the media from the web, finalising it to the defined location.
@@ -261,7 +268,7 @@ def fetch(self: Task, pk: str):
         lock.release()
 
 
-@shared_task(bind=True, ignore_result=False)
+@shared_task(name="slurp.cleanup_stale_tasks", bind=True, ignore_result=False)
 def cleanup_stale_tasks(self):
     """
     cleanup_stale_tasks removes persistent data about tasks that exceed the configured TASK_STALE duration.
@@ -296,7 +303,7 @@ def cleanup_stale_tasks(self):
     return ids
 
 
-@shared_task(bind=True)
+@shared_task(name="slurp.cleanup_task", bind=True)
 def cleanup_task(self, task_pk: str, events: bool = False):
     """
     cleanup_task removes data about the given task from the database, and attempts to remove any files related to the fetch.


### PR DESCRIPTION
This allows for the primary key of the task to be returned in the POST creation request.

The major downside of this is that if all workers are busy, the request to create the fetch may stall. I'm thinking about how to resolve this (likely with multiple queues) and will push a separate branch with a solution.